### PR TITLE
add all vsphere addons

### DIFF
--- a/flux-manifests/cluster-api-cleaner-vsphere.yaml
+++ b/flux-manifests/cluster-api-cleaner-vsphere.yaml
@@ -1,0 +1,13 @@
+api_version: generators.giantswarm.io/v1
+app_catalog: control-plane-catalog
+app_destination_namespace: giantswarm
+app_name: cluster-api-cleaner-vsphere
+app_version: 0.3.1
+kind: Konfigure
+metadata:
+  annotations:
+    config.kubernetes.io/function: |-
+      exec:
+        path: /plugins/konfigure
+  name: cluster-api-cleaner-vsphere
+name: cluster-api-cleaner-vsphere

--- a/flux-manifests/cluster-api-ipam-provider-in-cluster.yaml
+++ b/flux-manifests/cluster-api-ipam-provider-in-cluster.yaml
@@ -1,0 +1,13 @@
+api_version: generators.giantswarm.io/v1
+app_catalog: control-plane-catalog
+app_destination_namespace: giantswarm
+app_name: cluster-api-ipam-provider-in-cluster
+app_version: 0.1.1
+kind: Konfigure
+metadata:
+  annotations:
+    config.kubernetes.io/function: |-
+      exec:
+        path: /plugins/konfigure
+  name: cluster-api-ipam-provider-in-cluster
+name: cluster-api-ipam-provider-in-cluster

--- a/flux-manifests/cluster-api-provider-vsphere.yaml
+++ b/flux-manifests/cluster-api-provider-vsphere.yaml
@@ -1,0 +1,13 @@
+api_version: generators.giantswarm.io/v1
+app_catalog: control-plane-catalog
+app_destination_namespace: giantswarm
+app_name: cluster-api-provider-vsphere
+app_version: 0.12.1
+kind: Konfigure
+metadata:
+  annotations:
+    config.kubernetes.io/function: |-
+      exec:
+        path: /plugins/konfigure
+  name: cluster-api-provider-vsphere
+name: cluster-api-provider-vsphere

--- a/flux-manifests/kustomization.yaml
+++ b/flux-manifests/kustomization.yaml
@@ -1,0 +1,5 @@
+generators:
+- cluster-api-cleaner-vsphere.yaml
+- cluster-api-ipam-provider-in-cluster.yaml
+- cluster-api-provider-vsphere.yaml
+- dns-operator-route53.yaml


### PR DESCRIPTION
https://github.com/giantswarm/roadmap/issues/3624

### What does this PR do?

This adds all of the vsphere addons to this collection so that we only need to install this one for capa-capv environments instead of it in addition to the general addons collection.

### What is the effect of this change to users?

### How does it look like?

(Please add anything that represents the change visually. Screenshots, output, logs, ...)

### Any background context you can provide?

(Please link public issues or summarize if not public.)

### What is needed from the reviewers?

### Do the docs need to be updated?

### Should this change be mentioned in the release notes?

- [ ] CHANGELOG.md has been updated (if it exists)
