### PR TITLE
Convert to raw app crs (initial setup)

### DIFF
--- a/kustomize/cluster-api-cleaner-vsphere.yaml
+++ b/kustomize/cluster-api-cleaner-vsphere.yaml
@@ -1,0 +1,23 @@
+apiVersion: application.giantswarm.io/v1alpha1
+kind: App
+metadata:
+  annotations:
+    chart-operator.giantswarm.io/force-helm-upgrade: "true"
+  labels:
+    app-operator.giantswarm.io/version: 0.0.0
+  name: cluster-api-cleaner-vsphere
+  namespace: giantswarm
+spec:
+  catalog: control-plane-catalog
+  config:
+    configMap:
+      name: cluster-api-cleaner-vsphere-konfiguration
+      namespace: giantswarm
+    secret:
+      name: cluster-api-cleaner-vsphere-konfiguration
+      namespace: giantswarm
+  kubeConfig:
+    inCluster: true
+  name: cluster-api-cleaner-vsphere
+  namespace: giantswarm
+  version: 0.3.1

--- a/kustomize/cluster-api-ipam-provider-in-cluster.yaml
+++ b/kustomize/cluster-api-ipam-provider-in-cluster.yaml
@@ -1,0 +1,23 @@
+apiVersion: application.giantswarm.io/v1alpha1
+kind: App
+metadata:
+  annotations:
+    chart-operator.giantswarm.io/force-helm-upgrade: "true"
+  labels:
+    app-operator.giantswarm.io/version: 0.0.0
+  name: cluster-api-ipam-provider-in-cluster
+  namespace: giantswarm
+spec:
+  catalog: control-plane-catalog
+  config:
+    configMap:
+      name: cluster-api-ipam-provider-in-cluster-konfiguration
+      namespace: giantswarm
+    secret:
+      name: cluster-api-ipam-provider-in-cluster-konfiguration
+      namespace: giantswarm
+  kubeConfig:
+    inCluster: true
+  name: cluster-api-ipam-provider-in-cluster
+  namespace: giantswarm
+  version: 0.1.1

--- a/kustomize/cluster-api-provider-vsphere.yaml
+++ b/kustomize/cluster-api-provider-vsphere.yaml
@@ -1,0 +1,23 @@
+apiVersion: application.giantswarm.io/v1alpha1
+kind: App
+metadata:
+  annotations:
+    chart-operator.giantswarm.io/force-helm-upgrade: "true"
+  labels:
+    app-operator.giantswarm.io/version: 0.0.0
+  name: cluster-api-provider-vsphere
+  namespace: giantswarm
+spec:
+  catalog: control-plane-catalog
+  config:
+    configMap:
+      name: cluster-api-provider-vsphere-konfiguration
+      namespace: giantswarm
+    secret:
+      name: cluster-api-provider-vsphere-konfiguration
+      namespace: giantswarm
+  kubeConfig:
+    inCluster: true
+  name: cluster-api-provider-vsphere
+  namespace: giantswarm
+  version: 0.13.0

--- a/kustomize/dns-operator-route53.yaml
+++ b/kustomize/dns-operator-route53.yaml
@@ -1,0 +1,23 @@
+apiVersion: application.giantswarm.io/v1alpha1
+kind: App
+metadata:
+  annotations:
+    chart-operator.giantswarm.io/force-helm-upgrade: "true"
+  labels:
+    app-operator.giantswarm.io/version: 0.0.0
+  name: dns-operator-route53
+  namespace: giantswarm
+spec:
+  catalog: control-plane-catalog
+  config:
+    configMap:
+      name: dns-operator-route53-konfiguration
+      namespace: giantswarm
+    secret:
+      name: dns-operator-route53-konfiguration
+      namespace: giantswarm
+  kubeConfig:
+    inCluster: true
+  name: dns-operator-route53
+  namespace: giantswarm
+  version: 10.0.1

--- a/kustomize/image-distribution-operator.yaml
+++ b/kustomize/image-distribution-operator.yaml
@@ -1,0 +1,23 @@
+apiVersion: application.giantswarm.io/v1alpha1
+kind: App
+metadata:
+  annotations:
+    chart-operator.giantswarm.io/force-helm-upgrade: "true"
+  labels:
+    app-operator.giantswarm.io/version: 0.0.0
+  name: image-distribution-operator
+  namespace: giantswarm
+spec:
+  catalog: control-plane-catalog
+  config:
+    configMap:
+      name: image-distribution-operator-konfiguration
+      namespace: giantswarm
+    secret:
+      name: image-distribution-operator-konfiguration
+      namespace: giantswarm
+  kubeConfig:
+    inCluster: true
+  name: image-distribution-operator
+  namespace: giantswarm
+  version: 0.3.0

--- a/kustomize/konfiguration.yaml
+++ b/kustomize/konfiguration.yaml
@@ -1,0 +1,34 @@
+apiVersion: konfigure.giantswarm.io/v1alpha1
+kind: ManagementClusterConfiguration
+metadata:
+  name: collection-konfiguration
+  namespace: giantswarm
+spec:
+  configuration:
+    applications:
+      excludes: {}
+      includes:
+        exactMatchers:
+          - cluster-api-cleaner-vsphere
+          - cluster-api-ipam-provider-in-cluster
+          - cluster-api-provider-vsphere
+          - dns-operator-route53
+          - image-distribution-operator
+    cluster:
+      name: "${cluster_name}"
+  destination:
+    namespace: giantswarm
+    naming:
+      suffix: "konfiguration"
+      useSeparator: true
+  reconciliation:
+    interval: 1m0s
+    retryInterval: 10s
+    suspend: false
+  sources:
+    flux:
+      gitRepository:
+        name: giantswarm-config
+        namespace: flux-giantswarm
+      service:
+        url: source-controller.flux-giantswarm.svc

--- a/kustomize/konfiguration.yaml
+++ b/kustomize/konfiguration.yaml
@@ -1,7 +1,7 @@
 apiVersion: konfigure.giantswarm.io/v1alpha1
 kind: ManagementClusterConfiguration
 metadata:
-  name: collection-konfiguration
+  name: vsphere-aws-addons-collection-konfiguration
   namespace: giantswarm
 spec:
   configuration:

--- a/kustomize/kustomization.yaml
+++ b/kustomize/kustomization.yaml
@@ -1,0 +1,7 @@
+resources:
+- cluster-api-cleaner-vsphere.yaml
+- cluster-api-ipam-provider-in-cluster.yaml
+- cluster-api-provider-vsphere.yaml
+- dns-operator-route53.yaml
+- image-distribution-operator.yaml
+- konfiguration.yaml


### PR DESCRIPTION
The MCC gets a unique name here to avoid name collision with the "normal" collection this is used in conjunction with.